### PR TITLE
ci: upload binaries on release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,3 +16,15 @@ install:
 
 script:
   - make test-coverage
+
+before_deploy:
+  - make packages
+
+deploy:
+  provider: releases
+  api_key: $GITHUB_TOKEN
+  file_glob: true
+  file: build/*.tar.gz
+  skip_cleanup: true
+  on:
+    tags: true


### PR DESCRIPTION
Requires @mcuadros or @ajnavarro to add a `GITHUB_TOKEN` environment variable to the travis configuration.