### PR TITLE
internal/function: add commit_has_tree UDF

### DIFF
--- a/internal/function/commit_has_tree.go
+++ b/internal/function/commit_has_tree.go
@@ -1,0 +1,171 @@
+package function
+
+import (
+	"io"
+
+	"gopkg.in/src-d/go-git.v4/plumbing/filemode"
+	"gopkg.in/src-d/go-git.v4/plumbing/object"
+
+	"github.com/src-d/gitquery"
+	git "gopkg.in/src-d/go-git.v4"
+	"gopkg.in/src-d/go-git.v4/plumbing"
+	"gopkg.in/src-d/go-mysql-server.v0/sql"
+	"gopkg.in/src-d/go-mysql-server.v0/sql/expression"
+)
+
+// CommitHasTree is a function that checks whether a tree is part of a commit
+// or not.
+type CommitHasTree struct {
+	expression.BinaryExpression
+}
+
+// NewCommitHasTree creates a new CommitHasTree function.
+func NewCommitHasTree(commit, tree sql.Expression) sql.Expression {
+	return &CommitHasTree{expression.BinaryExpression{
+		Left:  commit,
+		Right: tree,
+	}}
+}
+
+// Name implements the Expression interface.
+func (CommitHasTree) Name() string { return "commit_has_tree" }
+
+// Type implements the Expression interface.
+func (CommitHasTree) Type() sql.Type { return sql.Boolean }
+
+// Eval implements the Expression interface.
+func (f *CommitHasTree) Eval(s sql.Session, row sql.Row) (interface{}, error) {
+	session, ok := s.(*gitquery.Session)
+	if !ok {
+		return nil, gitquery.ErrInvalidGitQuerySession.New(s)
+	}
+
+	left, err := f.Left.Eval(s, row)
+	if err != nil {
+		return nil, err
+	}
+
+	if left == nil {
+		return nil, nil
+	}
+
+	left, err = sql.Text.Convert(left)
+	if err != nil {
+		return nil, err
+	}
+
+	right, err := f.Right.Eval(s, row)
+	if err != nil {
+		return nil, err
+	}
+
+	if right == nil {
+		return nil, nil
+	}
+
+	right, err = sql.Text.Convert(right)
+	if err != nil {
+		return nil, err
+	}
+
+	commitHash := plumbing.NewHash(left.(string))
+	treeHash := plumbing.NewHash(right.(string))
+
+	iter, err := session.Pool.RepoIter()
+	if err != nil {
+		return nil, err
+	}
+
+	for {
+		repo, err := iter.Next()
+		if err == io.EOF {
+			return false, nil
+		}
+
+		if err != nil {
+			return nil, err
+		}
+
+		ok, err := commitHasTree(repo.Repo, commitHash, treeHash)
+		if err == plumbing.ErrObjectNotFound {
+			continue
+		}
+
+		return ok, nil
+	}
+}
+
+func commitHasTree(
+	repo *git.Repository,
+	commitHash, treeHash plumbing.Hash,
+) (bool, error) {
+	commit, err := repo.CommitObject(commitHash)
+	if err != nil {
+		return false, err
+	}
+
+	if commit.TreeHash == treeHash {
+		return true, nil
+	}
+
+	tree, err := commit.Tree()
+	if err != nil {
+		return false, err
+	}
+
+	return treeInEntries(repo, tree.Entries, treeHash)
+}
+
+func treeInEntries(
+	repo *git.Repository,
+	entries []object.TreeEntry,
+	hash plumbing.Hash,
+) (bool, error) {
+	type stackFrame struct {
+		pos     int
+		entries []object.TreeEntry
+	}
+	var stack = []*stackFrame{{0, entries}}
+
+	for {
+		if len(stack) == 0 {
+			return false, nil
+		}
+
+		frame := stack[len(stack)-1]
+		if frame.pos >= len(frame.entries) {
+			stack = stack[:len(stack)-1]
+			continue
+		}
+
+		entry := frame.entries[frame.pos]
+		frame.pos++
+		if entry.Mode == filemode.Dir {
+			if entry.Hash == hash {
+				return true, nil
+			}
+
+			tree, err := repo.TreeObject(entry.Hash)
+			if err != nil {
+				return false, nil
+			}
+
+			stack = append(stack, &stackFrame{0, tree.Entries})
+		}
+	}
+}
+
+// TransformUp implements the Expression interface.
+func (f *CommitHasTree) TransformUp(fn func(sql.Expression) (sql.Expression, error)) (sql.Expression, error) {
+	left, err := f.Left.TransformUp(fn)
+	if err != nil {
+		return nil, err
+	}
+
+	right, err := f.Right.TransformUp(fn)
+	if err != nil {
+		return nil, err
+	}
+
+	return fn(NewCommitHasTree(left, right))
+}

--- a/internal/function/commit_has_tree_test.go
+++ b/internal/function/commit_has_tree_test.go
@@ -1,0 +1,57 @@
+package function
+
+import (
+	"context"
+	"testing"
+
+	"github.com/src-d/gitquery"
+	"github.com/stretchr/testify/require"
+	fixtures "gopkg.in/src-d/go-git-fixtures.v3"
+	"gopkg.in/src-d/go-mysql-server.v0/sql"
+	"gopkg.in/src-d/go-mysql-server.v0/sql/expression"
+)
+
+func TestCommitHasTree(t *testing.T) {
+	require.NoError(t, fixtures.Init())
+	defer func() {
+		require.NoError(t, fixtures.Clean())
+	}()
+
+	f := NewCommitHasTree(
+		expression.NewGetField(0, sql.Text, "commit_hash", true),
+		expression.NewGetField(1, sql.Text, "tree_hash", true),
+	)
+
+	pool := gitquery.NewRepositoryPool()
+	for _, f := range fixtures.ByTag("worktree") {
+		pool.AddGit(f.Worktree().Root())
+	}
+
+	session := gitquery.NewSession(context.TODO(), &pool)
+
+	testCases := []struct {
+		name     string
+		row      sql.Row
+		expected interface{}
+		err      bool
+	}{
+		{"commit hash is null", sql.NewRow(nil, "foo"), nil, false},
+		{"tree hash is null", sql.NewRow("foo", nil), nil, false},
+		{"tree is not on commit", sql.NewRow("6ecf0ef2c2dffb796033e5a02219af86ec6584e5", "c2d30fa8ef288618f65f6eed6e168e0d514886f4"), false, false},
+		{"tree is on commit", sql.NewRow("e8d3ffab552895c19b9fcf7aa264d277cde33881", "dbd3641b371024f44d0e469a9c8f5457b0660de1"), true, false},
+		{"subtree is on commit", sql.NewRow("6ecf0ef2c2dffb796033e5a02219af86ec6584e5", "5a877e6a906a2743ad6e45d99c1793642aaf8eda"), true, false},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			require := require.New(t)
+			val, err := f.Eval(session, tt.row)
+			if tt.err {
+				require.Error(err)
+			} else {
+				require.NoError(err)
+				require.Equal(tt.expected, val)
+			}
+		})
+	}
+}

--- a/internal/function/registry.go
+++ b/internal/function/registry.go
@@ -7,6 +7,7 @@ var functions = map[string]sql.Function{
 	"is_remote":       sql.Function1(NewIsRemote),
 	"commit_has_blob": sql.Function2(NewCommitHasBlob),
 	"history_idx":     sql.Function2(NewHistoryIdx),
+	"commit_has_tree": sql.Function2(NewCommitHasTree),
 }
 
 // Register all the gitquery functions in the SQL catalog.


### PR DESCRIPTION
Closes #152 

# Important pls readme

Note that another, perhaps simpler, solution would be to add a `tree` column to the `commits` table (since the tree hash is in the commit object) and then just `commits.tree = tree_entries.tree_hash`